### PR TITLE
CUBE-4554: update commitizen package to close vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "chalk": "4.1.0",
-    "commitizen": "^4.2.4",
+    "commitizen": "4.2.4",
     "conventional-commit-types": "3.0.0",
     "lodash.map": "4.6.0",
     "longest": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "chalk": "4.1.0",
-    "commitizen": "4.2.3",
+    "commitizen": "^4.2.4",
     "conventional-commit-types": "3.0.0",
     "lodash.map": "4.6.0",
     "longest": "2.0.1",


### PR DESCRIPTION
CUBE-4554: Commitizen `4.2.3` has a dependency on a version of `merge` with a security vulnerability. By updating to `4.2.4`, we can close a few Dependabot security warnings raised on downstream repos depending on `cz-cube`.